### PR TITLE
feat: display multiple addresses on about page - closes AQE-19

### DIFF
--- a/src/_content/addresses.ts
+++ b/src/_content/addresses.ts
@@ -1,0 +1,21 @@
+interface Address {
+  name: string;
+  address: string;
+  mapLink: string;
+}
+
+export const addresses = [
+  {
+    name: "Selangor (HQ)",
+    address:
+      "10, Jalan Delta U6/19, Sunway Subang Business Park, 40150 Shah Alam, Selangor",
+    mapLink: "https://maps.app.goo.gl/pvt4L46jAopBCbWJ6",
+  },
+  {
+    name: "Penang",
+    address:
+      "55, Jalan Perai Jaya 5, Bandar Perai Jaya, 13700 Perai, Pulau Pinang",
+    mapLink: "https://maps.app.goo.gl/YYnu3aMXYTvHAxLS9",
+  },
+  // Add more addresses as needed
+] satisfies Address[];

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -11,13 +11,13 @@ import { ButtonVariant2 } from "~/components/Button";
 import { WHATSAPP_LINK } from "~/links";
 import { Statistic } from "~/components/Statistic";
 import { Pattern } from "~/components/Pattern";
+import { addresses } from "~/_content/addresses";
 import AboutHeroImage from "~/../public/images/about/about-hero.png";
 import Container from "~/components/Container";
 import Hero from "~/components/Hero";
 import SectionHeader from "~/components/SectionHeader";
 import SupplierLogos from "~/components/SupplierLogos";
 import OurStory from "./OurStory";
-import { addresses } from "~/_content/addresses";
 
 export const metadata: Metadata = {
   title: "About AQ Energy",

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -17,6 +17,7 @@ import Hero from "~/components/Hero";
 import SectionHeader from "~/components/SectionHeader";
 import SupplierLogos from "~/components/SupplierLogos";
 import OurStory from "./OurStory";
+import { addresses } from "~/_content/addresses";
 
 export const metadata: Metadata = {
   title: "About AQ Energy",
@@ -205,16 +206,27 @@ const AboutPage = () => {
                 </Icon>
                 hello@aq.energy
               </a>
-              <a
-                href="https://goo.gl/maps/6cN1wHW1SR6MivpD8"
-                className="flex items-start gap-3 py-5 sm:px-4 md:py-0 lg:px-6 xl:items-center"
-              >
-                <Icon>
-                  <MapPinIcon className="h-6 w-6" />
-                </Icon>
-                10, Jalan Delta U6/19, Sunway Subang Business Park, 40150 Shah
-                Alam, Selangor
-              </a>
+            </div>
+            <h2 className="mb-6 mt-6 text-left font-semibold text-gray-800 sm:mt-10 sm:text-center">
+              Find us at these locations
+            </h2>
+            {/* Addresses */}
+            <div className="mx-auto grid w-full grid-cols-1 gap-4 text-sm  sm:grid-cols-2 lg:w-[40rem]">
+              {addresses.map((location) => (
+                <a
+                  key={location.name}
+                  href={location.mapLink}
+                  className="items-left flex flex-col gap-2 rounded-md border p-4 text-black-coral hover:bg-indigo-dye hover:text-white"
+                >
+                  <div className="flex items-center gap-3">
+                    <Icon>
+                      <MapPinIcon className="h-6 w-6" />
+                    </Icon>
+                    <span className="font-semibold">{location.name}</span>
+                  </div>
+                  <span>{location.address}</span>
+                </a>
+              ))}
             </div>
           </div>
         </Container>

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from "next";
-import { EnvelopeIcon, MapPinIcon } from "@heroicons/react/20/solid";
+import { EnvelopeIcon } from "@heroicons/react/20/solid";
 import { CheckBadgeIcon } from "@heroicons/react/24/solid";
 
 // import Portrait from "../components/Portrait";
@@ -12,6 +12,7 @@ import { WHATSAPP_LINK } from "~/links";
 import { Statistic } from "~/components/Statistic";
 import { Pattern } from "~/components/Pattern";
 import { addresses } from "~/_content/addresses";
+import { AddressButton } from "~/components/AddressButton";
 import AboutHeroImage from "~/../public/images/about/about-hero.png";
 import Container from "~/components/Container";
 import Hero from "~/components/Hero";
@@ -211,21 +212,14 @@ const AboutPage = () => {
               Find us at these locations
             </h2>
             {/* Addresses */}
-            <div className="mx-auto grid w-full grid-cols-1 gap-4 text-sm  sm:grid-cols-2 lg:w-[40rem]">
+            <div className="mx-auto grid w-full grid-cols-1 gap-4 text-sm sm:grid-cols-2 lg:w-[40rem]">
               {addresses.map((location) => (
-                <a
+                <AddressButton
                   key={location.name}
-                  href={location.mapLink}
-                  className="items-left flex flex-col gap-2 rounded-md border p-4 text-black-coral hover:bg-indigo-dye hover:text-white"
-                >
-                  <div className="flex items-center gap-3">
-                    <Icon>
-                      <MapPinIcon className="h-6 w-6" />
-                    </Icon>
-                    <span className="font-semibold">{location.name}</span>
-                  </div>
-                  <span>{location.address}</span>
-                </a>
+                  name={location.name}
+                  mapLink={location.mapLink}
+                  address={location.address}
+                />
               ))}
             </div>
           </div>

--- a/src/components/AddressButton.tsx
+++ b/src/components/AddressButton.tsx
@@ -13,11 +13,11 @@ export const AddressButton = ({
   return (
     <a
       href={mapLink}
-      className="items-left flex flex-col gap-2 rounded-md border p-4 text-black-coral hover:bg-indigo-dye hover:text-white"
+      className="items-left group flex flex-col gap-2 rounded-md border p-4 text-black-coral transition ease-in-out hover:bg-indigo-dye hover:text-white"
     >
       <div className="flex items-center gap-3">
-        <Icon>
-          <MapPinIcon className="h-6 w-6" />
+        <Icon className="transition group-hover:bg-indigo-dye">
+          <MapPinIcon className="h-6 w-6 transition group-hover:fill-cyber-yellow" />
         </Icon>
         <span className="font-semibold">{name}</span>
       </div>

--- a/src/components/AddressButton.tsx
+++ b/src/components/AddressButton.tsx
@@ -1,0 +1,27 @@
+import { MapPinIcon } from "@heroicons/react/24/solid";
+import Icon from "./Icon";
+
+export const AddressButton = ({
+  name,
+  mapLink,
+  address,
+}: {
+  name: string;
+  mapLink: string;
+  address: string;
+}) => {
+  return (
+    <a
+      href={mapLink}
+      className="items-left flex flex-col gap-2 rounded-md border p-4 text-black-coral hover:bg-indigo-dye hover:text-white"
+    >
+      <div className="flex items-center gap-3">
+        <Icon>
+          <MapPinIcon className="h-6 w-6" />
+        </Icon>
+        <span className="font-semibold">{name}</span>
+      </div>
+      <span>{address}</span>
+    </a>
+  );
+};

--- a/src/components/AddressButton.tsx
+++ b/src/components/AddressButton.tsx
@@ -1,27 +1,25 @@
 import { MapPinIcon } from "@heroicons/react/24/solid";
 import Icon from "./Icon";
 
-export const AddressButton = ({
-  name,
-  mapLink,
-  address,
-}: {
+interface AddressButtonProps {
   name: string;
   mapLink: string;
   address: string;
-}) => {
+}
+
+export const AddressButton = (props: AddressButtonProps) => {
   return (
     <a
-      href={mapLink}
+      href={props.mapLink}
       className="items-left group flex flex-col gap-2 rounded-md border p-4 text-black-coral transition ease-in-out hover:bg-indigo-dye hover:text-white"
     >
       <div className="flex items-center gap-3">
         <Icon className="transition group-hover:bg-indigo-dye">
           <MapPinIcon className="h-6 w-6 transition group-hover:fill-cyber-yellow" />
         </Icon>
-        <span className="font-semibold">{name}</span>
+        <span className="font-semibold">{props.name}</span>
       </div>
-      <span>{address}</span>
+      <span>{props.address}</span>
     </a>
   );
 };


### PR DESCRIPTION
https://github.com/user-attachments/assets/578af50a-3e74-473e-86d8-e442e028f87c

![image](https://github.com/user-attachments/assets/bbcdebfe-0450-4eab-9479-94853baf29ba)

This pull request introduces a new `Address` interface and a list of addresses in the `addresses.ts` file, and integrates these addresses into the `About` page. The changes enhance the `About` page by dynamically displaying multiple office locations.

### Introduction of Address Interface and Data:

* [`src/_content/addresses.ts`](diffhunk://#diff-ab3450d25adb9ec06c09967f091f8272cbfb01f47c173ae42c058b1351c14c20R1-R21): Added a new `Address` interface and a list of address objects for different office locations.

### Integration of Addresses into About Page:

* [`src/app/about/page.tsx`](diffhunk://#diff-d38aaae18142756b8b93ec0043df16888550dfded455e182cc0e4a81eb8286e2R20): Imported the `addresses` from `addresses.ts` and incorporated them into the `AboutPage` component to dynamically display office locations with links and formatted addresses. [[1]](diffhunk://#diff-d38aaae18142756b8b93ec0043df16888550dfded455e182cc0e4a81eb8286e2R20) [[2]](diffhunk://#diff-d38aaae18142756b8b93ec0043df16888550dfded455e182cc0e4a81eb8286e2R209-R229)